### PR TITLE
[VIT-2813] Fix a retain cycle in VitalHealthRN

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -387,13 +387,13 @@ PODS:
   - RNVectorIcons (9.2.0):
     - React-Core
   - SocketRocket (0.6.0)
-  - vital-core-react-native (1.4.0):
+  - vital-core-react-native (1.4.1):
     - React-Core
     - VitalCore (~> 0.9.3)
-  - vital-devices-react-native (1.4.0):
+  - vital-devices-react-native (1.4.1):
     - React-Core
     - VitalDevices (~> 0.9.3)
-  - vital-health-react-native (1.4.0):
+  - vital-health-react-native (1.4.1):
     - React-Core
     - VitalHealthKit (~> 0.9.3)
   - VitalCore (0.9.3)
@@ -649,9 +649,9 @@ SPEC CHECKSUMS:
   RNSVG: d7d7bc8229af3842c9cfc3a723c815a52cdd1105
   RNVectorIcons: fcc2f6cb32f5735b586e66d14103a74ce6ad61f8
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  vital-core-react-native: 5785ecf9c9ba484a12521c3824e2e4a8e0fcd26d
-  vital-devices-react-native: 9390a5a630ee570c63e9b4f6aa9393bb6def3f11
-  vital-health-react-native: 008d953d30ee435622f4fbcc699f8e1f95841073
+  vital-core-react-native: 0aa966d4bb489cca13c6f960d06b978f0f6f8dfd
+  vital-devices-react-native: 7e3caaf4acfec41720a1effb2f8a095c07d0963d
+  vital-health-react-native: dc3bd15104cfccc6877bcb335fbb835631f1e92e
   VitalCore: 7f0f3e05411169b212218c02f5f9299711e4d937
   VitalDevices: ec15b9ed34dc25e9ba52765d29dd7455308d32be
   VitalHealthKit: 084a6624fbe5318e149cd612acb11cfb5b6929f0

--- a/packages/vital-health-react-native/ios/VitalHealthReactNative.swift
+++ b/packages/vital-health-react-native/ios/VitalHealthReactNative.swift
@@ -16,7 +16,7 @@ class VitalHealthReactNative: RCTEventEmitter {
     super.init()
     VitalHealthReactNative.status = self
 
-    cancellable = VitalHealthKitClient.shared.status.sink { status in
+    cancellable = VitalHealthKitClient.shared.status.sink { [weak self] status in
       var payload: [String: String] = [:]
 
       switch status {
@@ -41,7 +41,7 @@ class VitalHealthReactNative: RCTEventEmitter {
           payload["status"] = "completed"
       }
 
-      self.sendEvent(withName: "Status", body: payload)
+      self?.sendEvent(withName: "Status", body: payload)
     }
   }
 


### PR DESCRIPTION
When Metro reloads, anything native module related is also disposed of and recreated.

`VitalHealthReactNative` event emitter has a retain cycle with a Publisher subscription, and therefore keeping it from deallocating. Then when the Publisher subscription attempts to send a value, it crashes due to the event emitter being a dead instance that should not be used.