### PR TITLE
[VIT-2923] RN Android: Support posting timeseries data via vital-core

### DIFF
--- a/example/src/ExampleUseCases.tsx
+++ b/example/src/ExampleUseCases.tsx
@@ -67,12 +67,10 @@ async function readScannedGlucoseMeter(
     console.log("@@@ Read " + samples.length + " samples from device: " + device.name + " (id = " + device.id + ")")
     console.log(samples)
 
-    if (Platform.OS == "ios") {
-        await VitalCore.postTimeSeriesData(
-            { "type": "glucose", "samples": samples },
-            ProviderSlug.AccuchekBLE
-        )
-    }
+    await VitalCore.postTimeSeriesData(
+        { "type": "glucose", "samples": samples },
+        ProviderSlug.AccuchekBLE
+    )
 
     return samples
 }

--- a/packages/vital-core-react-native/android/build.gradle
+++ b/packages/vital-core-react-native/android/build.gradle
@@ -135,6 +135,7 @@ dependencies {
     //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
   api "com.squareup.moshi:moshi:1.13.0"
   api "com.squareup.moshi:moshi-kotlin:1.13.0"
   api "com.squareup.moshi:moshi-adapters:1.13.0"

--- a/packages/vital-core-react-native/android/src/main/java/com/vitalcorereactnative/VitalCoreReactNativeModule.kt
+++ b/packages/vital-core-react-native/android/src/main/java/com/vitalcorereactnative/VitalCoreReactNativeModule.kt
@@ -4,9 +4,30 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.Promise
+import com.facebook.react.module.annotations.ReactModule
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapter
+import io.tryvital.client.Environment
+import io.tryvital.client.Region
+import io.tryvital.client.VitalClient
+import io.tryvital.client.services.data.ManualProviderSlug
+import io.tryvital.client.services.data.TimeseriesPayload
+import io.tryvital.client.utils.VitalLogger
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import java.time.ZoneId
 
+const val VITAL_CORE_ERROR = "VitalCoreError"
+
+@ReactModule(name = VitalCoreReactNativeModule.NAME)
 class VitalCoreReactNativeModule(reactContext: ReactApplicationContext) :
   ReactContextBaseJavaModule(reactContext) {
+
+  private val mainScope = MainScope()
+  var client: VitalClient? = null
+
+  // TODO: VIT-2924 user ID management is misplaced. For now assume VitalHealth is always used.
+  var userId: String? = null
 
   override fun getName(): String {
     return NAME
@@ -14,12 +35,26 @@ class VitalCoreReactNativeModule(reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun setUserId(userId: String, promise: Promise) {
-    promise.resolve(null)
+    promise.reject(VITAL_CORE_ERROR, "setUserId is unimplemented at VitalCore; Please use setUserId at VitalHealth for the time being.")
   }
 
   @ReactMethod
   fun configure(apiKey: String, environment: String, region: String, enableLogs: Boolean, promise: Promise) {
-    promise.resolve(null)
+    try {
+      VitalLogger.getOrCreate().enabled = enableLogs
+
+      client = VitalClient(
+        reactApplicationContext,
+        // TODO: Expose these as enum constants in the RN SDK
+        region = Region.valueOf(region.uppercase()),
+        environment = Environment.valueOf(environment.lowercase().replaceFirstChar { it.uppercase() }),
+        apiKey = apiKey
+      )
+
+      promise.resolve(null)
+    } catch (e: IllegalArgumentException) {
+      promise.reject(VITAL_CORE_ERROR, e.message, e)
+    }
   }
 
   @ReactMethod
@@ -27,7 +62,78 @@ class VitalCoreReactNativeModule(reactContext: ReactApplicationContext) :
     promise.resolve(null)
   }
 
+  @ReactMethod
+  @OptIn(ExperimentalStdlibApi::class)
+  fun postTimeSeriesData(jsonString: String, provider: String, timeZoneString: String?, promise: Promise) {
+    val client = client ?: return promise.rejectCoreNotConfigured()
+    val userId = userId ?: return promise.rejectUserIDNotSet()
+
+    val slug = try { ManualProviderSlug.valueOf(provider) } catch (e: IllegalArgumentException) {
+      return promise.reject(VITAL_CORE_ERROR, "Unrecognized manual provider: $provider")
+    }
+
+    val timeZone = if (timeZoneString != null) {
+      try {
+        ZoneId.of(timeZoneString)
+      } catch (e: Exception) {
+        promise.reject(VITAL_CORE_ERROR, "Unrecognized named time zone: $timeZoneString", e)
+        return
+      }
+    } else {
+      ZoneId.systemDefault()
+    }
+
+    val moshi = Moshi.Builder().add(ReactNativeTimeSeriesData.adapter()).build()
+    val adapter = moshi.adapter<ReactNativeTimeSeriesData>()
+
+    val data = adapter.fromJson(jsonString)
+    if (data == null) {
+      promise.reject(VITAL_CORE_ERROR, "Failed to decode the provided JSON String.", null)
+      return
+    }
+
+    fun <T> makeTimeseriesPayload(data: T) = TimeseriesPayload(
+      stage = "daily",
+      provider = slug,
+      startDate = null,
+      endDate = null,
+      timeZoneId = timeZone.id,
+      data = data,
+    )
+
+    mainScope.launch {
+      try {
+        when (data) {
+          is ReactNativeTimeSeriesData.Glucose ->
+            client.vitalsService.sendGlucose(
+              userId = userId,
+              glucosePayloads = makeTimeseriesPayload(
+                data.samples.map { it.payload }
+              )
+            )
+          is ReactNativeTimeSeriesData.BloodPressure ->
+            client.vitalsService.sendBloodPressure(
+              userId = userId,
+              timeseriesPayload = makeTimeseriesPayload(
+                data.samples.map { it.payload }
+              )
+            )
+        }
+
+        promise.resolve(null)
+      } catch (e: Exception) {
+        promise.reject(VITAL_CORE_ERROR, "${(e::class.simpleName ?: "")}: ${e.message}", e)
+      }
+    }
+  }
+
   companion object {
     const val NAME = "VitalCoreReactNative"
   }
 }
+
+private fun Promise.rejectCoreNotConfigured()
+  = reject(VITAL_CORE_ERROR, "VitalCore client has not been configured.")
+
+private fun Promise.rejectUserIDNotSet()
+  = reject(VITAL_CORE_ERROR, "User ID has not been set.")

--- a/packages/vital-core-react-native/android/src/main/java/com/vitalcorereactnative/timeSeriesData.kt
+++ b/packages/vital-core-react-native/android/src/main/java/com/vitalcorereactnative/timeSeriesData.kt
@@ -1,0 +1,55 @@
+package com.vitalcorereactnative
+
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
+import io.tryvital.client.services.data.BloodPressureSamplePayload
+import io.tryvital.client.services.data.QuantitySamplePayload
+import java.util.*
+
+
+sealed class ReactNativeTimeSeriesData {
+  data class Glucose(val samples: List<ReactNativeQuantitySample>): ReactNativeTimeSeriesData()
+  data class BloodPressure(val samples: List<ReactNativeBloodPressureSample>): ReactNativeTimeSeriesData()
+
+  companion object {
+    fun adapter() = PolymorphicJsonAdapterFactory
+      .of(ReactNativeTimeSeriesData::class.java, "type")
+      .withSubtype(Glucose::class.java, "glucose")
+      .withSubtype(BloodPressure::class.java, "blood_pressure")
+  }
+}
+
+data class ReactNativeQuantitySample(
+  val id: String?,
+  val value: Double,
+  // JS Date is stringified via `Date.toISOString()` - ISO8601
+  val startDate: Date,
+  val endDate: Date,
+  val sourceBundle: String?,
+  val productType: String?,
+  val type: String?,
+  val unit: String,
+) {
+  val payload get() = QuantitySamplePayload(
+    id = id,
+    value = value,
+    startDate = startDate,
+    endDate = endDate,
+    sourceBundle = sourceBundle,
+    deviceModel = productType,
+    type = type,
+    unit = unit,
+    metadata = null
+  )
+}
+
+data class ReactNativeBloodPressureSample(
+  val systolic: ReactNativeQuantitySample,
+  val diastolic: ReactNativeQuantitySample,
+  val pulse: ReactNativeQuantitySample?,
+) {
+  val payload get() = BloodPressureSamplePayload(
+    systolic = systolic.payload,
+    diastolic = diastolic.payload,
+    pulse = pulse?.payload
+  )
+}

--- a/packages/vital-core-react-native/src/index.ts
+++ b/packages/vital-core-react-native/src/index.ts
@@ -43,9 +43,6 @@ export class VitalCore {
     );
   }
 
-  /**
-   * @deprecated Experiment API: Not yet implemented in Android
-   */
   static postTimeSeriesData(
     data: TimeSeriesData,
     provider: ManualProviderSlug,

--- a/packages/vital-health-react-native/android/build.gradle
+++ b/packages/vital-health-react-native/android/build.gradle
@@ -142,6 +142,8 @@ dependencies {
   implementation "com.github.tryVital.vital-android:VitalClient:$vital_sdk_version"
   implementation "com.github.tryVital.vital-android:VitalHealthConnect:$vital_sdk_version"
   implementation "androidx.health.connect:connect-client:$health_connect_version"
+
+  implementation project(':tryvital_vital-core-react-native')
 // From node_modules
 }
 


### PR DESCRIPTION

* Implement `postTimeSeriesData` in vital-core-rn for Android.

* Have an instance of `VitalClient` and a copy of user ID in the VitalCoreReactNative module, so that we can make API calls from there.

    * Ideally the Android SDK would be singleton-ized so we don't need to do this in RN. But at the moment, this is not the case.
