### PR TITLE
[VIT-2947] Adopt Android SDK 1.0.0-beta.14

### DIFF
--- a/packages/vital-core-react-native/android/gradle.properties
+++ b/packages/vital-core-react-native/android/gradle.properties
@@ -1,4 +1,4 @@
-VitalCoreReactNative_kotlinVersion=1.7.0
+VitalCoreReactNative_kotlinVersion=1.8.10
 VitalCoreReactNative_minSdkVersion=21
 VitalCoreReactNative_targetSdkVersion=31
 VitalCoreReactNative_compileSdkVersion=31

--- a/packages/vital-devices-react-native/android/build.gradle
+++ b/packages/vital-devices-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.10'
+def vital_sdk_version = '1.0.0-beta.12'
 
 dependencies {
   //noinspection GradleDynamicVersion

--- a/packages/vital-devices-react-native/android/build.gradle
+++ b/packages/vital-devices-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.12'
+def vital_sdk_version = '1.0.0-beta.13'
 
 dependencies {
   //noinspection GradleDynamicVersion

--- a/packages/vital-devices-react-native/android/build.gradle
+++ b/packages/vital-devices-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.13'
+def vital_sdk_version = '1.0.0-beta.14'
 
 dependencies {
   //noinspection GradleDynamicVersion

--- a/packages/vital-devices-react-native/android/gradle.properties
+++ b/packages/vital-devices-react-native/android/gradle.properties
@@ -1,4 +1,4 @@
-VitalDevicesReactNative_kotlinVersion=1.7.0
+VitalDevicesReactNative_kotlinVersion=1.8.10
 VitalDevicesReactNative_minSdkVersion=26
 VitalDevicesReactNative_targetSdkVersion=33
 VitalDevicesReactNative_compileSdkVersion=33

--- a/packages/vital-health-react-native/android/build.gradle
+++ b/packages/vital-health-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.10'
+def vital_sdk_version = '1.0.0-beta.12'
 def health_connect_version = '1.0.0-alpha11'
 
 dependencies {

--- a/packages/vital-health-react-native/android/build.gradle
+++ b/packages/vital-health-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.12'
+def vital_sdk_version = '1.0.0-beta.13'
 def health_connect_version = '1.0.0-alpha11'
 
 dependencies {

--- a/packages/vital-health-react-native/android/build.gradle
+++ b/packages/vital-health-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.13'
+def vital_sdk_version = '1.0.0-beta.14'
 def health_connect_version = '1.0.0-alpha11'
 
 dependencies {

--- a/packages/vital-health-react-native/android/gradle.properties
+++ b/packages/vital-health-react-native/android/gradle.properties
@@ -1,4 +1,4 @@
-VitalHealthReactNative_kotlinVersion=1.7.0
+VitalHealthReactNative_kotlinVersion=1.8.10
 VitalHealthReactNative_minSdkVersion=26
 VitalHealthReactNative_targetSdkVersion=31
 VitalHealthReactNative_compileSdkVersion=31


### PR DESCRIPTION
* Adopt the new Vital Health Connect permission API from Android.

* Clean up the usage of CoroutineScope. Only one is needed, and it only needs to be cancelled in `cleanUp()` or when we recreate `VitalHealthConnectManager` in `configure()`.