### PR TITLE
[VIT-3065] Fix RN interop JSON decoding

### DIFF
--- a/example/src/ExampleUseCases.tsx
+++ b/example/src/ExampleUseCases.tsx
@@ -91,10 +91,10 @@ async function readScannedGlucoseMeter(
     console.log("@@@ Read " + samples.length + " samples from device: " + device.name + " (id = " + device.id + ")")
     console.log(samples)
 
-    await VitalCore.createConnectedSourceIfNotExist(ProviderSlug.OmronBLE)
+    await VitalCore.createConnectedSourceIfNotExist(ManualProviderSlug.OmronBLE)
     await VitalCore.postTimeSeriesData(
         { "type": "glucose", "samples": samples },
-        ProviderSlug.AccuchekBLE
+        ManualProviderSlug.AccuchekBLE
     )
 
     return samples
@@ -146,10 +146,10 @@ async function readScannedBloodPressureMeter(
     console.log("@@@ Read " + samples.length + " samples from device: " + device.name + " (id = " + device.id + ")")
     console.log(samples)
 
-    await VitalCore.createConnectedSourceIfNotExist(ProviderSlug.OmronBLE)
+    await VitalCore.createConnectedSourceIfNotExist(ManualProviderSlug.OmronBLE)
     await VitalCore.postTimeSeriesData(
         { "type": "blood_pressure", "samples": samples },
-        ProviderSlug.OmronBLE
+        ManualProviderSlug.OmronBLE
     )
 
     return samples

--- a/packages/vital-core-react-native/android/build.gradle
+++ b/packages/vital-core-react-native/android/build.gradle
@@ -142,6 +142,8 @@ dependencies {
 
   implementation "com.github.tryVital.vital-android:VitalClient:$vital_sdk_version"
 
+  testImplementation "junit:junit:4.13.2"
+
 // From node_modules
 }
 

--- a/packages/vital-core-react-native/android/src/main/java/com/vitalcorereactnative/VitalCoreReactNativeModule.kt
+++ b/packages/vital-core-react-native/android/src/main/java/com/vitalcorereactnative/VitalCoreReactNativeModule.kt
@@ -9,6 +9,8 @@ import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.module.annotations.ReactModule
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
+import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.tryvital.client.*
 import io.tryvital.client.services.data.ManualProviderSlug
 import io.tryvital.client.services.data.ProviderSlug
@@ -19,8 +21,17 @@ import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import java.security.Provider
 import java.time.ZoneId
+import java.util.*
 
 const val VITAL_CORE_ERROR = "VitalCoreError"
+
+internal val moshi by lazy {
+  Moshi.Builder()
+    .add(ReactNativeTimeSeriesData.adapterFactory())
+    .add(Date::class.java, Rfc3339DateJsonAdapter())
+    .addLast(KotlinJsonAdapterFactory())
+    .build()
+}
 
 @ReactModule(name = VitalCoreReactNativeModule.NAME)
 class VitalCoreReactNativeModule(reactContext: ReactApplicationContext) :
@@ -147,7 +158,6 @@ class VitalCoreReactNativeModule(reactContext: ReactApplicationContext) :
       ZoneId.systemDefault()
     }
 
-    val moshi = Moshi.Builder().add(ReactNativeTimeSeriesData.adapter()).build()
     val adapter = moshi.adapter<ReactNativeTimeSeriesData>()
 
     val data = adapter.fromJson(jsonString)

--- a/packages/vital-core-react-native/android/src/main/java/com/vitalcorereactnative/timeSeriesData.kt
+++ b/packages/vital-core-react-native/android/src/main/java/com/vitalcorereactnative/timeSeriesData.kt
@@ -11,7 +11,7 @@ sealed class ReactNativeTimeSeriesData {
   data class BloodPressure(val samples: List<ReactNativeBloodPressureSample>): ReactNativeTimeSeriesData()
 
   companion object {
-    fun adapter() = PolymorphicJsonAdapterFactory
+    fun adapterFactory(): PolymorphicJsonAdapterFactory<ReactNativeTimeSeriesData> = PolymorphicJsonAdapterFactory
       .of(ReactNativeTimeSeriesData::class.java, "type")
       .withSubtype(Glucose::class.java, "glucose")
       .withSubtype(BloodPressure::class.java, "blood_pressure")

--- a/packages/vital-core-react-native/android/src/test/java/com/vitalcorereactnative/SerializationTests.kt
+++ b/packages/vital-core-react-native/android/src/test/java/com/vitalcorereactnative/SerializationTests.kt
@@ -1,0 +1,98 @@
+package com.vitalcorereactnative
+
+import com.squareup.moshi.adapter
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.Instant
+import java.util.*
+
+
+class SerializationTests {
+  @OptIn(ExperimentalStdlibApi::class)
+  @Test
+  fun canDeserializeGlucoseSamples() {
+    val date = "2023-01-23T12:34:56Z"
+    val jsonString = """
+    {
+      "type": "glucose",
+      "samples": [
+        {
+          "id":"id", "value":123.0, "startDate":"$date", "endDate":"$date",
+          "sourceBundle":"source", "productType":"product", "type":"fingerprick", "unit":"mmol/L"
+        }
+      ]
+    }
+    """.trimIndent()
+    val adapter = moshi.adapter<ReactNativeTimeSeriesData>()
+
+    assertEquals(
+      adapter.fromJson(jsonString),
+      ReactNativeTimeSeriesData.Glucose(
+        listOf(
+          ReactNativeQuantitySample(
+            id = "id",
+            value = 123.0,
+            startDate = Date.from(Instant.parse(date)),
+            endDate = Date.from(Instant.parse(date)),
+            sourceBundle = "source",
+            productType = "product",
+            type = "fingerprick",
+            unit = "mmol/L",
+          )
+        )
+      )
+    )
+  }
+
+  @OptIn(ExperimentalStdlibApi::class)
+  @Test
+  fun canDeserializeBloodPressureSamples() {
+    val date = "2023-01-23T12:34:56Z"
+    val jsonString = """
+    {
+      "type": "blood_pressure",
+      "samples": [
+        {
+          "systolic": {
+            "id":"id", "value":100.0, "startDate":"$date", "endDate":"$date",
+            "sourceBundle":"source", "productType":"product", "type":"cuff", "unit":"mmHg"
+          },
+          "diastolic": {
+            "id":"id", "value":90.0, "startDate":"$date", "endDate":"$date",
+            "sourceBundle":"source", "productType":"product", "type":"cuff", "unit":"mmHg"
+          },
+          "pulse": {
+            "id":"id", "value":80.0, "startDate":"$date", "endDate":"$date",
+            "sourceBundle":"source", "productType":"product", "type":"cuff", "unit":"bpm"
+          }
+        }
+      ]
+    }
+    """.trimIndent()
+    val adapter = moshi.adapter<ReactNativeTimeSeriesData>()
+
+    fun makeSample(value: Double, unit: String) = ReactNativeQuantitySample(
+      id = "id",
+      value = value,
+      startDate = Date.from(Instant.parse(date)),
+      endDate = Date.from(Instant.parse(date)),
+      sourceBundle = "source",
+      productType = "product",
+      type = "cuff",
+      unit = unit,
+    )
+
+    assertEquals(
+      adapter.fromJson(jsonString),
+      ReactNativeTimeSeriesData.BloodPressure(
+        listOf(
+          ReactNativeBloodPressureSample(
+            systolic = makeSample(value = 100.0, unit = "mmHg"),
+            diastolic = makeSample(value = 90.0, unit = "mmHg"),
+            pulse = makeSample(value = 80.0, unit = "bpm"),
+          )
+        )
+      )
+    )
+  }
+}


### PR DESCRIPTION
The reflection-based Moshi JSON has not been configured properly, so payloads from RN weren't deserialised as expected.

e.g. missing adapter for `java.time.Date` and missing `KotlinJsonAdapterFactory`.