### PR TITLE
VIT-4376: RN interop for Android Libre1Reader

### DIFF
--- a/packages/vital-core-react-native/android/build.gradle
+++ b/packages/vital-core-react-native/android/build.gradle
@@ -129,7 +129,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.17'
+def vital_sdk_version = '1.0.0-beta.18'
 
 dependencies {
     //noinspection GradleDynamicVersion

--- a/packages/vital-devices-react-native/android/build.gradle
+++ b/packages/vital-devices-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.17'
+def vital_sdk_version = '1.0.0-beta.18'
 
 dependencies {
   //noinspection GradleDynamicVersion

--- a/packages/vital-devices-react-native/src/index.ts
+++ b/packages/vital-devices-react-native/src/index.ts
@@ -77,15 +77,19 @@ export class VitalDevicesManager {
   }
 
   async readLibre1(readingMessage: string, errorMessage: string, completionMessage: string): Promise<Libre1Read> {
-    if (Platform.OS == "android") {
-      throw new Error("readLibre1 does not support Android at this time")
-    }
+    let response: Libre1Read
 
-    let response: Libre1Read = await NativeModules.VitalDevicesReactNative.readLibre1WithReadingMessage(
-      readingMessage,
-      errorMessage,
-      completionMessage
-    )
+    if (Platform.OS == "android") {
+      response = await NativeModules.VitalDevicesReactNative.readLibre1()
+    } else if (Platform.OS == "ios") {
+      response = await NativeModules.VitalDevicesReactNative.readLibre1WithReadingMessage(
+        readingMessage,
+        errorMessage,
+        completionMessage
+      )
+    } else {
+      throw Error(`Libre1 is not supported on ${Platform.OS}`)
+    }
 
     return response
   }

--- a/packages/vital-devices-react-native/src/model/scanned_device.ts
+++ b/packages/vital-devices-react-native/src/model/scanned_device.ts
@@ -7,7 +7,7 @@ export interface ScannedDevice {
   deviceModel: DeviceModel;
 }
 
-export type Libre1SensorState = "unknown" | "not_activated" | "warming_up" | "active" | "expired" | "shutdown" | "failure";
+export type Libre1SensorState = "unknown" | "notActivated" | "warmingUp" | "active" | "expired" | "shutdown" | "failure";
 
 export default interface Libre1Sensor {
   serial: string,

--- a/packages/vital-health-react-native/android/build.gradle
+++ b/packages/vital-health-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.17'
+def vital_sdk_version = '1.0.0-beta.18'
 def health_connect_version = '1.0.0-alpha11'
 
 dependencies {


### PR DESCRIPTION
Bump Android SDK to 1.0.0-beta.18

Update RN interop to forward readLibre1 calls to the new Android Libre1Reader.


