### PR TITLE
VIT-4376: readLibre1 fixes and update example

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation"/>
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
 
+    <uses-permission android:name="android.permission.NFC" />
+
     <!-- Request legacy Bluetooth permissions on older devices. -->
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30"/>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -15,14 +15,14 @@ import {
 } from '@tryvital/vital-devices-react-native';
 import {NativeEventEmitter} from 'react-native';
 import {VITAL_API_KEY, VITAL_ENVIRONMENT, VITAL_REGION} from './Environment';
-import {syncWearableData, readBLEGlucoseMeter, readBLEBloodPressureMeter, inspectUserConnectedSources} from './ExampleUseCases';
+import {syncWearableData, readBLEGlucoseMeter, readBLEBloodPressureMeter, inspectUserConnectedSources, readLibre1} from './ExampleUseCases';
 import { initializeVitalSDK } from './Initialization';
 
 // Configuring Vital client SDK for making API calls on client side
 // Recommended way is to do this on the backend but for the sake of an example
 // You can do it on the client side
 export const vitalNodeClient = new VitalClient({
-  environment: VITAL_ENVIRONMENT,
+  environment: VITAL_ENVIRONMENT == "dev" ? "development" : VITAL_ENVIRONMENT,
   api_key: VITAL_API_KEY,
   region: VITAL_REGION,
 });
@@ -52,7 +52,10 @@ const App = () => {
       await syncWearableData()
 
       // Example: Read BLE Glucose Meter
-      await readBLEGlucoseMeter(vitalDevicesManager)
+      // await readBLEGlucoseMeter(vitalDevicesManager)
+
+      // Example: Read Freestyle Libre 1 via NFC
+      await readLibre1(vitalDevicesManager)
 
       // Example: Read BLE Blood Pressure
       // await readBLEBloodPressureMeter(vitalDevicesManager)

--- a/example/src/ExampleUseCases.tsx
+++ b/example/src/ExampleUseCases.tsx
@@ -1,6 +1,7 @@
 import { ManualProviderSlug, VitalCore } from "@tryvital/vital-core-react-native";
 import { Brand, Cancellable, DeviceKind, ScannedDevice, VitalDevicesManager } from "@tryvital/vital-devices-react-native";
 import { VitalHealth, VitalResource } from "@tryvital/vital-health-react-native";
+import { Platform } from "react-native";
 import { PERMISSIONS, requestMultiple } from "react-native-permissions";
 
 // VitalHealth example use case: Sync Wearable data
@@ -98,6 +99,27 @@ async function readScannedGlucoseMeter(
     )
 
     return samples
+}
+
+// VitalDevice example use case: Read BLE Glucose meter
+export async function readLibre1(
+    deviceManager: VitalDevicesManager
+) {
+    // NOTE: Your Android app manifest should have requested NFC permissions:
+    // <uses-permission android:name="android.permission.NFC" />
+
+    console.log("@@@ Start scanning for Libre1")
+
+    let result = await deviceManager.readLibre1("reading", "errored", "completed")
+    console.log(`@@@ Did read Libre1: ${JSON.stringify(result, null, 2)}`)
+
+    await VitalCore.createConnectedSourceIfNotExist(ManualProviderSlug.LibreBLE)
+    await VitalCore.postTimeSeriesData(
+        { "type": "glucose", "samples": result.samples },
+        ManualProviderSlug.LibreBLE
+    )
+
+    console.log("@@@ Did post Libre1 timeseries data")
 }
 
 // VitalDevice example use case: Read BLE Blood Pressure meter

--- a/packages/vital-devices-react-native/src/index.ts
+++ b/packages/vital-devices-react-native/src/index.ts
@@ -6,7 +6,7 @@ import { checkMultiple, PERMISSIONS } from 'react-native-permissions';
 
 import type { BloodPressureSample, QuantitySample } from '@tryvital/vital-core-react-native';
 import type { ScannedDevice } from './model/scanned_device';
-import type Libre1Read from './model/scanned_device';
+import type { Libre1Read } from './model/scanned_device';
 
 export * from './model/device_model';
 export * from './model/brand';
@@ -91,7 +91,10 @@ export class VitalDevicesManager {
       throw Error(`Libre1 is not supported on ${Platform.OS}`)
     }
 
-    return response
+    return {
+      samples: response.samples.map(fix_quantity_sample),
+      sensor: response.sensor,
+    }
   }
 
   async pairDevice(scannedDeviceId: string): Promise<void> {

--- a/packages/vital-devices-react-native/src/model/scanned_device.ts
+++ b/packages/vital-devices-react-native/src/model/scanned_device.ts
@@ -9,14 +9,14 @@ export interface ScannedDevice {
 
 export type Libre1SensorState = "unknown" | "notActivated" | "warmingUp" | "active" | "expired" | "shutdown" | "failure";
 
-export default interface Libre1Sensor {
+export interface Libre1Sensor {
   serial: string,
   maxLife: number,
   age: number,
   state: Libre1SensorState
 }
 
-export default interface Libre1Read {
+export interface Libre1Read {
   samples: QuantitySample[],
   sensor: Libre1Sensor
 }


### PR DESCRIPTION
1. Fixed readLibre1 not having fixed up the quantity samples for JS environment.

2. Updated React Native example app with a Libre1 example code path.


