### PR TITLE
VIT-5546: Workaround React Native internals breaking AndroidX Activity Result Contracts

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -258,6 +258,8 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "com.facebook.react:flipper-integration"
 
+    implementation "androidx.work:work-runtime:2.3.1"
+
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,8 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30"/>
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
     <!-- BEGIN: Health Connect permissions -->
     <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED" />
     <uses-permission android:name="android.permission.health.READ_BASAL_METABOLIC_RATE" />
@@ -61,12 +63,42 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+        </activity>
 
-            <!-- TODO create a rational page for the privacy policy-->
+
+        <!-- BEGIN: Mandatory for Health Connect permission flow -->
+        <activity
+            android:name=".PermissionsRationaleActivity"
+            android:exported="true">
             <intent-filter>
-                <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE"/>
+                <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
             </intent-filter>
         </activity>
 
+        <!-- For versions starting Android 14, create an activity alias to show the rationale
+             of Health Connect permissions once users click the privacy policy link. -->
+        <activity-alias
+            android:name="ViewPermissionUsageActivity"
+            android:exported="true"
+            android:targetActivity=".MainActivity"
+            android:permission="android.permission.START_VIEW_PERMISSION_USAGE">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW_PERMISSION_USAGE" />
+                <category android:name="android.intent.category.HEALTH_PERMISSIONS" />
+            </intent-filter>
+        </activity-alias>
+        <!-- END: Mandatory for Health Connect permission flow -->
+
+        <!-- BEGIN: Mandatory for running Health Connect as foreground service on Android 14+ -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="shortService"
+            android:exported="false">
+        </service>
+        <!-- END: Mandatory for running Health Connect as foreground service on Android 14+ -->
     </application>
+
+    <queries>
+        <package android:name="com.google.android.apps.healthdata" />
+    </queries>
 </manifest>

--- a/example/android/app/src/main/java/com/example/MainActivity.java
+++ b/example/android/app/src/main/java/com/example/MainActivity.java
@@ -3,8 +3,9 @@ package com.example;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
+import com.vitalhealthreactnative.VitalHealthReactActivity;
 
-public class MainActivity extends ReactActivity {
+public class MainActivity extends VitalHealthReactActivity {
 
   /**
    * Returns the name of the main component registered from JavaScript. This is used to schedule

--- a/example/android/app/src/main/java/com/example/PermissionsRationaleActivity.kt
+++ b/example/android/app/src/main/java/com/example/PermissionsRationaleActivity.kt
@@ -1,0 +1,6 @@
+package com.example
+
+import androidx.activity.ComponentActivity
+
+class PermissionsRationaleActivity: ComponentActivity() {
+}

--- a/example/package.json
+++ b/example/package.json
@@ -18,9 +18,9 @@
   "dependencies": {
     "@react-navigation/native": "^6.1.7",
     "@react-navigation/native-stack": "^6.9.17",
-    "@tryvital/vital-core-react-native": "^2.0.2",
-    "@tryvital/vital-devices-react-native": "^2.0.2",
-    "@tryvital/vital-health-react-native": "^2.0.2",
+    "@tryvital/vital-core-react-native": "link:../packages/vital-core-react-native",
+    "@tryvital/vital-devices-react-native": "link:../packages/vital-devices-react-native",
+    "@tryvital/vital-health-react-native": "link:../packages/vital-health-react-native",
     "@tryvital/vital-node": "^2.1.20",
     "@types/react-native-vector-icons": "^6.4.13",
     "events": "^1.1.1",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2966,30 +2966,21 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
-"@tryvital/vital-core-react-native@^1.3.0":
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/@tryvital/vital-core-react-native/-/vital-core-react-native-1.13.1.tgz#14a1ec9fc9ffc459eeda4941e6d3d1252b8c0313"
-  integrity sha512-LbQMCu4zX/JYgstgT+KjJU7tiYmswxDUIxyp9ZnEN096OBYRj1H8c1yDOEmJeoFk+7vfK4ktrgfxXr0expGseQ==
+"@tryvital/vital-core-react-native@^3.0.1":
+  version "0.0.0"
+  uid ""
 
-"@tryvital/vital-core-react-native@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@tryvital/vital-core-react-native/-/vital-core-react-native-2.0.2.tgz#8f3816c219c6457ee0a005bc9e313266678db642"
-  integrity sha512-87N6CgsCJCmndanvilYObMG1hzny4bmgWx3GscBMLwwWqxcJz/t8bbJNADqOBUvIYm66O/SMup5M8j4q5qCiBA==
+"@tryvital/vital-core-react-native@link:../packages/vital-core-react-native":
+  version "0.0.0"
+  uid ""
 
-"@tryvital/vital-devices-react-native@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@tryvital/vital-devices-react-native/-/vital-devices-react-native-2.0.2.tgz#0e412a7f1ac5d87b0085f6230f9ba852bc2f0540"
-  integrity sha512-lkBGjJxbj2dp4LvfSQTClsFrMzF3Oepxi7M5MG9DKOkawFsurmUtBtDyCXDLekge2/3VETbcbLW0NaYVBUGBMg==
-  dependencies:
-    "@tryvital/vital-core-react-native" "^1.3.0"
-    react-native-permissions "^3.6.1"
+"@tryvital/vital-devices-react-native@link:../packages/vital-devices-react-native":
+  version "0.0.0"
+  uid ""
 
-"@tryvital/vital-health-react-native@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@tryvital/vital-health-react-native/-/vital-health-react-native-2.0.2.tgz#6e6efd1eea873c010295a1d3c2e58c9c81a784a3"
-  integrity sha512-J2Dwu/9THyOEk81gGkVLQH6FbVW6D3UuNZ515KOgrmN9Mric2WtzHQNc/EgY6voZROR3lKpt9QcwrzqDrqazHw==
-  dependencies:
-    "@tryvital/vital-core-react-native" "^1.3.0"
+"@tryvital/vital-health-react-native@link:../packages/vital-health-react-native":
+  version "0.0.0"
+  uid ""
 
 "@tryvital/vital-node@^2.1.20":
   version "2.1.20"

--- a/packages/vital-core-react-native/android/build.gradle
+++ b/packages/vital-core-react-native/android/build.gradle
@@ -129,7 +129,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.24'
+def vital_sdk_version = '1.0.0-beta.25'
 
 dependencies {
     //noinspection GradleDynamicVersion

--- a/packages/vital-devices-react-native/android/build.gradle
+++ b/packages/vital-devices-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.24'
+def vital_sdk_version = '1.0.0-beta.25'
 
 dependencies {
   //noinspection GradleDynamicVersion

--- a/packages/vital-health-react-native/android/build.gradle
+++ b/packages/vital-health-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.24'
+def vital_sdk_version = '1.0.0-beta.25'
 
 dependencies {
     //noinspection GradleDynamicVersion

--- a/packages/vital-health-react-native/android/src/main/java/com/vitalhealthreactnative/VitalHealthReactActivity.kt
+++ b/packages/vital-health-react-native/android/src/main/java/com/vitalhealthreactnative/VitalHealthReactActivity.kt
@@ -1,0 +1,26 @@
+package com.vitalhealthreactnative
+
+import android.annotation.SuppressLint
+import com.facebook.react.ReactActivity
+
+/**
+ * [VitalHealthReactActivity] is a workaround to React Native Android not properly overriding
+ * [ComponentActivity.onRequestPermissionsResult], breaking AndroidX activity result contracts.
+ */
+open class VitalHealthReactActivity: ReactActivity() {
+  @SuppressLint("VisibleForTests")
+  override fun onRequestPermissionsResult(
+    requestCode: Int,
+    permissions: Array<out String>,
+    grantResults: IntArray
+  ) {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+
+    VitalHealthReactNativeModule.onRequestPermissionsResult(
+      this.reactInstanceManager,
+      requestCode,
+      permissions,
+      grantResults
+    )
+  }
+}


### PR DESCRIPTION
The way in which React Native overrides ComponentActivity.onRequestPermissionsResult breaks at the very least permission request contracts.

This includes Health Connect permission request contracts, which can no longer be launched on Android 14+ via startActivityForResult, given its reliance on special codepaths inside AndroidX ActivityResultRegistry to transform the AndroidX intent (`androidx.activity.result.contract.action.REQUEST_PERMISSIONS`) to the proper OS permission manager intent (`android.content.pm.action.REQUEST_PERMISSIONS`).

This PR applies a workaround to the issue, though it requires the host app to either:

1. Override `ReactActivity.onRequestPermissionsResult` and call `VitalHealthReactNativeModule.Companion.onRequestPermissionsResult` themselves.

2. Use the provided `com.vitalhealthreactnative.VitalHealthReactActivity` to substitute the ReactActivity superclass of their MainActivity.

Note that there is absolutely zero guarantee that this would not break again in the future, since both React Native and Android/AndroidX evolve with their own directives.