### PR TITLE
CS1-97: Improve AGP 7.3.x release minification compatibility

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     ext {
+        kotlinVersion = "1.8.10"
         buildToolsVersion = "34.0.0"
         minSdkVersion = 26
         compileSdkVersion = 34
@@ -20,9 +21,10 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:8.2.0')
+        classpath('com.android.tools.build:gradle:7.3.0')
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:5.0.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/packages/vital-core-react-native/android/build.gradle
+++ b/packages/vital-core-react-native/android/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     classpath 'com.android.tools.build:gradle:3.5.3'
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    classpath "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:$kotlin_version+"
   }
 }
 
@@ -20,6 +21,7 @@ def isNewArchitectureEnabled() {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'com.google.devtools.ksp'
 
 if (isNewArchitectureEnabled()) {
   apply plugin: 'com.facebook.react'
@@ -129,15 +131,16 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.27'
+def vital_sdk_version = '1.0.0-beta.28'
 
 dependencies {
+  ksp "com.squareup.moshi:moshi-kotlin-codegen:1.13.0"
+
     //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
   api "com.squareup.moshi:moshi:1.13.0"
-  api "com.squareup.moshi:moshi-kotlin:1.13.0"
   api "com.squareup.moshi:moshi-adapters:1.13.0"
 
   implementation "com.github.tryVital.vital-android:VitalClient:$vital_sdk_version"

--- a/packages/vital-core-react-native/android/src/main/java/com/vitalcorereactnative/VitalCoreReactNativeModule.kt
+++ b/packages/vital-core-react-native/android/src/main/java/com/vitalcorereactnative/VitalCoreReactNativeModule.kt
@@ -12,7 +12,6 @@ import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
 import com.squareup.moshi.adapters.Rfc3339DateJsonAdapter
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.tryvital.client.*
 import io.tryvital.client.services.data.DataStage
 import io.tryvital.client.services.data.IngestibleTimeseriesResource
@@ -26,7 +25,6 @@ import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import java.security.Provider
 import java.time.ZoneId
 import java.util.*
 
@@ -36,7 +34,6 @@ internal val moshi by lazy {
   Moshi.Builder()
     .add(ReactNativeTimeSeriesData.adapterFactory())
     .add(Date::class.java, Rfc3339DateJsonAdapter())
-    .addLast(KotlinJsonAdapterFactory())
     .build()
 }
 

--- a/packages/vital-core-react-native/android/src/main/java/com/vitalcorereactnative/timeSeriesData.kt
+++ b/packages/vital-core-react-native/android/src/main/java/com/vitalcorereactnative/timeSeriesData.kt
@@ -1,13 +1,17 @@
 package com.vitalcorereactnative
 
+import com.squareup.moshi.JsonClass
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import io.tryvital.client.services.data.BloodPressureSamplePayload
 import io.tryvital.client.services.data.QuantitySamplePayload
 import java.util.*
 
 
+@JsonClass(generateAdapter = false)
 sealed class ReactNativeTimeSeriesData {
+  @JsonClass(generateAdapter = true)
   data class Glucose(val samples: List<ReactNativeQuantitySample>): ReactNativeTimeSeriesData()
+  @JsonClass(generateAdapter = true)
   data class BloodPressure(val samples: List<ReactNativeBloodPressureSample>): ReactNativeTimeSeriesData()
 
   companion object {
@@ -18,6 +22,7 @@ sealed class ReactNativeTimeSeriesData {
   }
 }
 
+@JsonClass(generateAdapter = true)
 data class ReactNativeQuantitySample(
   val id: String?,
   val value: Double,
@@ -42,6 +47,7 @@ data class ReactNativeQuantitySample(
   )
 }
 
+@JsonClass(generateAdapter = true)
 data class ReactNativeBloodPressureSample(
   val systolic: ReactNativeQuantitySample,
   val diastolic: ReactNativeQuantitySample,

--- a/packages/vital-devices-react-native/android/build.gradle
+++ b/packages/vital-devices-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.27'
+def vital_sdk_version = '1.0.0-beta.28'
 
 dependencies {
   //noinspection GradleDynamicVersion

--- a/packages/vital-health-react-native/android/build.gradle
+++ b/packages/vital-health-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.27'
+def vital_sdk_version = '1.0.0-beta.28'
 
 dependencies {
     //noinspection GradleDynamicVersion


### PR DESCRIPTION
Bump to Android SDK 1.0.0-beta.28
* CS1-95: Android: Migrate serialization from reflection to codegen by @andersio in https://github.com/tryVital/vital-android/pull/89
    * Improves compatibility with R8 minification under Android Gradle Plugin 7.3.x+.

