### PR TITLE
CS1-163: RN: Release new SDK with signOut()

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1133,21 +1133,21 @@ PODS:
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
   - SocketRocket (0.6.1)
-  - vital-core-react-native (3.0.5):
+  - vital-core-react-native (3.0.7):
     - React-Core
-    - VitalCore (~> 0.10.11)
-  - vital-devices-react-native (3.0.5):
+    - VitalCore (~> 0.11.2)
+  - vital-devices-react-native (3.0.7):
     - React-Core
-    - VitalDevices (~> 0.10.11)
-  - vital-health-react-native (3.0.5):
+    - VitalDevices (~> 0.11.2)
+  - vital-health-react-native (3.0.7):
     - React-Core
-    - VitalHealthKit (~> 0.10.11)
-  - VitalCore (0.10.11)
-  - VitalDevices (0.10.11):
+    - VitalHealthKit (~> 0.11.2)
+  - VitalCore (0.11.2)
+  - VitalDevices (0.11.2):
     - CombineCoreBluetooth (~> 0.3.1)
-    - VitalCore (~> 0.10.11)
-  - VitalHealthKit (0.10.11):
-    - VitalCore (~> 0.10.11)
+    - VitalCore (~> 0.11.2)
+  - VitalHealthKit (0.11.2):
+    - VitalCore (~> 0.11.2)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -1447,12 +1447,12 @@ SPEC CHECKSUMS:
   RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a
   RNVectorIcons: 210f910e834e3485af40693ad4615c1ec22fc02b
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  vital-core-react-native: 44b1f6974d6d40ba04b1fd559b6c23dd5fd90714
-  vital-devices-react-native: a8c8ccb2ad900ab3f1efe3c6b497b113647a9772
-  vital-health-react-native: 35ad79255eb8bef715efb08c1a7dfb84149176b0
-  VitalCore: 6ec2c2df343522829d83425d5a86c5761fd8ee2c
-  VitalDevices: efb219648a60e91a31c060cd70e52bb1e5fbb117
-  VitalHealthKit: a3b5881bd6fae0938e88080298559bd055921f25
+  vital-core-react-native: 4b6862f07699c81bbc430e089f1678b090be6745
+  vital-devices-react-native: 77024cb3bf0e392ec58896274a22fc584d4a1f31
+  vital-health-react-native: 22e06279b9955ec928f760323847fee4e6455a26
+  VitalCore: 5443e4c23da56398d487c8829533f31273c119da
+  VitalDevices: 3e70b0d50a3faa160c24764183f008b429910223
+  VitalHealthKit: f06cb55774e61bb9c3a6dbfe2cd415513c7d2605
   Yoga: 2b33a7ac96c58cdaa7b810948fc6a2a76ed2d108
 
 PODFILE CHECKSUM: 2a537c5b3fef93a43656a06053f42e15c4747741

--- a/example/src/screens/UserScreen.tsx
+++ b/example/src/screens/UserScreen.tsx
@@ -143,7 +143,7 @@ export const UserScreen = ({route, navigation}) => {
 
         {
             !isCurrentSDKUser && isSDKConfigured &&
-            <Button onPress={() => VitalHealth.cleanUp()}>
+            <Button onPress={() => VitalCore.signOut()}>
                 Reset SDK
             </Button>
         }

--- a/packages/vital-core-react-native/android/build.gradle
+++ b/packages/vital-core-react-native/android/build.gradle
@@ -131,7 +131,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.28'
+def vital_sdk_version = '1.0.0-beta.30'
 
 dependencies {
   ksp "com.squareup.moshi:moshi-kotlin-codegen:1.13.0"

--- a/packages/vital-core-react-native/android/src/main/java/com/vitalcorereactnative/VitalCoreReactNativeModule.kt
+++ b/packages/vital-core-react-native/android/src/main/java/com/vitalcorereactnative/VitalCoreReactNativeModule.kt
@@ -130,10 +130,10 @@ class VitalCoreReactNativeModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  fun cleanUp(promise: Promise) {
+  fun signOut(promise: Promise) {
     mainScope.launch {
       try {
-        client.cleanUp()
+        client.signOut()
         promise.resolve(null)
       } catch (e: Throwable) {
         promise.reject(VITAL_CORE_ERROR, e.message, e)

--- a/packages/vital-core-react-native/ios/VitalCoreReactNative.m
+++ b/packages/vital-core-react-native/ios/VitalCoreReactNative.m
@@ -44,7 +44,7 @@ RCT_EXTERN_METHOD(deregisterProvider:(NSString *)provider
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(cleanUp:(RCTPromiseResolveBlock)resolve
+RCT_EXTERN_METHOD(signOut:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(sdkVersion:(RCTPromiseResolveBlock)resolve

--- a/packages/vital-core-react-native/ios/VitalCoreReactNative.swift
+++ b/packages/vital-core-react-native/ios/VitalCoreReactNative.swift
@@ -204,10 +204,10 @@ class VitalCoreReactNative: RCTEventEmitter {
     }
   }
 
-  @objc(cleanUp:rejecter:)
-  func cleanUp(resolve:@escaping RCTPromiseResolveBlock, reject:RCTPromiseRejectBlock) {
+  @objc(signOut:rejecter:)
+  func signOut(resolve:@escaping RCTPromiseResolveBlock, reject:RCTPromiseRejectBlock) {
     Task {
-      await VitalClient.shared.cleanUp()
+      await VitalClient.shared.signOut()
       resolve(())
     }
   }

--- a/packages/vital-core-react-native/src/index.ts
+++ b/packages/vital-core-react-native/src/index.ts
@@ -144,7 +144,14 @@ export class VitalCore {
     return VitalCoreReactNative.sdkVersion();
   }
 
+  static signOut(): Promise<void> {
+    return VitalCoreReactNative.signOut();
+  }
+
+  /**
+   * @deprecated Renamed to `signOut()`.
+   */
   static cleanUp(): Promise<void> {
-    return VitalCoreReactNative.cleanUp();
+    return this.signOut();
   }
 }

--- a/packages/vital-core-react-native/vital-core-react-native.podspec
+++ b/packages/vital-core-react-native/vital-core-react-native.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "VitalCore", "~> 0.11.1"
+  s.dependency "VitalCore", "~> 0.11.2"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then

--- a/packages/vital-devices-react-native/android/build.gradle
+++ b/packages/vital-devices-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.28'
+def vital_sdk_version = '1.0.0-beta.30'
 
 dependencies {
   //noinspection GradleDynamicVersion

--- a/packages/vital-devices-react-native/vital-devices-react-native.podspec
+++ b/packages/vital-devices-react-native/vital-devices-react-native.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "VitalDevices", "~> 0.11.1"
+  s.dependency "VitalDevices", "~> 0.11.2"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then

--- a/packages/vital-health-react-native/android/build.gradle
+++ b/packages/vital-health-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '1.0.0-beta.28'
+def vital_sdk_version = '1.0.0-beta.30'
 
 dependencies {
     //noinspection GradleDynamicVersion

--- a/packages/vital-health-react-native/android/src/main/java/com/vitalhealthreactnative/VitalHealthReactNativeModule.kt
+++ b/packages/vital-health-react-native/android/src/main/java/com/vitalhealthreactnative/VitalHealthReactNativeModule.kt
@@ -222,14 +222,6 @@ class VitalHealthReactNativeModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  fun cleanUp(promise: Promise) {
-    mainScope.launch {
-      vitalHealthConnectManager.cleanUp()
-      promise.resolve(null)
-    }
-  }
-
-  @ReactMethod
   private fun writeHealthData(
     resource: String,
     startDate: Long,

--- a/packages/vital-health-react-native/ios/VitalHealthReactNative.m
+++ b/packages/vital-health-react-native/ios/VitalHealthReactNative.m
@@ -35,9 +35,6 @@ RCT_EXTERN_METHOD(writeHealthData:(NSString *)resource
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(cleanUp:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
-
 RCT_EXTERN_METHOD(hasAskedForPermission:(NSString *)resource
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)

--- a/packages/vital-health-react-native/ios/VitalHealthReactNative.swift
+++ b/packages/vital-health-react-native/ios/VitalHealthReactNative.swift
@@ -167,14 +167,6 @@ class VitalHealthReactNative: RCTEventEmitter {
     }
   }
 
-  @objc(cleanUp:rejecter:)
-  func cleanUp(_ resolve: @escaping RCTPromiseResolveBlock, reject:RCTPromiseRejectBlock) {
-    Task {
-      await VitalHealthKitClient.shared.cleanUp()
-      resolve(())
-    }
-  }
-
   @objc(hasAskedForPermission:resolver:rejecter:)
   func hasAskedForPermission(_ resource: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
     do {

--- a/packages/vital-health-react-native/src/index.tsx
+++ b/packages/vital-health-react-native/src/index.tsx
@@ -1,5 +1,6 @@
 import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
 import type { HealthConfig } from './health_config';
+import { VitalCore } from '@tryvital/vital-core-react-native';
 
 // Reexports
 export * from './health_config';
@@ -105,8 +106,12 @@ export class VitalHealth {
     return VitalHealthReactNative.syncData(resources);
   }
 
+  /**
+   * @deprecated Use `VitalCore.signOut()`, which now resets both the Vital Core
+   * and Health SDKs.
+   */
   static cleanUp(): Promise<void> {
-    return VitalHealthReactNative.cleanUp();
+    return VitalCore.signOut();
   }
 }
 

--- a/packages/vital-health-react-native/vital-health-react-native.podspec
+++ b/packages/vital-health-react-native/vital-health-react-native.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "VitalHealthKit", "~> 0.11.1"
+  s.dependency "VitalHealthKit", "~> 0.11.2"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then


### PR DESCRIPTION
Bump iOS to 0.11.2
Bump Android to 1.0.0-beta.30.

Rename `cleanUp()` to `signOut()`.