### PR TITLE
Bump up vital sdk version to 2.0.0

### DIFF
--- a/packages/vital-core-react-native/android/build.gradle
+++ b/packages/vital-core-react-native/android/build.gradle
@@ -131,7 +131,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '2.0.0-rc.1'
+def vital_sdk_version = '2.0.0'
 
 dependencies {
   ksp "com.squareup.moshi:moshi-kotlin-codegen:1.13.0"

--- a/packages/vital-devices-react-native/android/build.gradle
+++ b/packages/vital-devices-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '2.0.0-rc.1'
+def vital_sdk_version = '2.0.0'
 
 dependencies {
   //noinspection GradleDynamicVersion

--- a/packages/vital-health-react-native/android/build.gradle
+++ b/packages/vital-health-react-native/android/build.gradle
@@ -130,7 +130,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
-def vital_sdk_version = '2.0.0-rc.1'
+def vital_sdk_version = '2.0.0'
 
 dependencies {
     //noinspection GradleDynamicVersion


### PR DESCRIPTION
The latest vital-sdk-version is 2.0.0 referencing this https://github.com/tryVital/vital-android/releases/tag/2.0.0.

Android fails to build with the following stack trace:

```
* What went wrong:
Could not determine the dependencies of task ':app:processDebugResources'.
> Could not resolve all task dependencies for configuration ':app:debugRuntimeClasspath'.
   > Could not find com.github.tryVital.vital-android:VitalClient:2.0.0-rc.1.
     Searched in the following locations:
       - https://oss.sonatype.org/content/repositories/snapshots/com/github/tryVital/vital-android/VitalClient/2.0.0-rc.1/VitalClient-2.0.0-rc.1.pom
       - https://repo.maven.apache.org/maven2/com/github/tryVital/vital-android/VitalClient/2.0.0-rc.1/VitalClient-2.0.0-rc.1.pom
       - file:/Users/eddieogola/dev/app/wone/wone-app/node_modules/jsc-android/dist/com/github/tryVital/vital-android/VitalClient/2.0.0-rc.1/VitalClient-2.0.0-rc.1.pom
       - https://dl.google.com/dl/android/maven2/com/github/tryVital/vital-android/VitalClient/2.0.0-rc.1/VitalClient-2.0.0-rc.1.pom
       - https://www.jitpack.io/com/github/tryVital/vital-android/VitalClient/2.0.0-rc.1/VitalClient-2.0.0-rc.1.pom
       - file:/Users/eddieogola/dev/app/wone/wone-app/node_modules/react-native/android/com/github/tryVital/vital-android/VitalClient/2.0.0-rc.1/VitalClient-2.0.0-rc.1.pom
     Required by:
         project :app > project :tryvital_vital-core-react-native
         project :app > project :tryvital_vital-health-react-native
         project :app > project :tryvital_vital-health-react-native > com.github.tryVital.vital-android:VitalHealthConnect:2.0.0-rc.1
```


