### PR TITLE
Swizzle UIApplication setDelegate: for no native code setup

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1133,13 +1133,13 @@ PODS:
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
   - SocketRocket (0.6.1)
-  - vital-core-react-native (3.1.0-beta.5):
+  - vital-core-react-native (3.1.0):
     - React-Core
     - VitalCore (~> 0.11.6)
-  - vital-devices-react-native (3.1.0-beta.5):
+  - vital-devices-react-native (3.1.0):
     - React-Core
     - VitalDevices (~> 0.11.6)
-  - vital-health-react-native (3.1.0-beta.5):
+  - vital-health-react-native (3.1.0):
     - React-Core
     - VitalHealthKit (~> 0.11.6)
   - VitalCore (0.11.6)
@@ -1447,9 +1447,9 @@ SPEC CHECKSUMS:
   RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a
   RNVectorIcons: 210f910e834e3485af40693ad4615c1ec22fc02b
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  vital-core-react-native: 454c39d9f96ce1921807bdd79bc3524090cc2593
-  vital-devices-react-native: 70fdcfa4c46a6c14b86b54ad5de8f9ded9f7b9a6
-  vital-health-react-native: 1da64e84b9fad62847ceeff870c51e873953d28c
+  vital-core-react-native: 962045093662e695e8711942958885a7b74c81bb
+  vital-devices-react-native: 5a6feb9534b9d58b402f9dd27ea7316799114241
+  vital-health-react-native: d6813e4fb121e85208ae55ab30b7f6c8dde55636
   VitalCore: 9c03ec79ff09cfb4b7b72aee06b17e60e3fdf081
   VitalDevices: 200ffdcd00bb55eceb09699aeff26dc956ae5bdf
   VitalHealthKit: de4ec52dc9d661241ade035cefc5b2f07fd54844

--- a/example/ios/example/AppDelegate.mm
+++ b/example/ios/example/AppDelegate.mm
@@ -1,6 +1,4 @@
 #import "AppDelegate.h"
-#import "VitalHealthKitConfiguration.h"
-#import "VitalCoreConfiguration.h"
 
 #import <React/RCTBundleURLProvider.h>
 

--- a/packages/vital-health-react-native/ios/VitalAppDelegateProxy.h
+++ b/packages/vital-health-react-native/ios/VitalAppDelegateProxy.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface VitalAppDelegateProxy : NSObject <UIApplicationDelegate>
++ (instancetype)proxyWithBase:(id<UIApplicationDelegate>)delegate;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/vital-health-react-native/ios/VitalAppDelegateProxy.m
+++ b/packages/vital-health-react-native/ios/VitalAppDelegateProxy.m
@@ -1,0 +1,39 @@
+#import "VitalAppDelegateProxy.h"
+#import "VitalHealthKitConfiguration.h"
+
+@interface VitalAppDelegateProxy ()
+@property(strong, nonatomic) id<UIApplicationDelegate> delegate;
+@end
+
+@implementation VitalAppDelegateProxy
+@synthesize delegate;
+
++ (instancetype)proxyWithBase:(id<UIApplicationDelegate>)delegate {
+  VitalAppDelegateProxy *proxy = [[VitalAppDelegateProxy alloc] init];
+  proxy.delegate = delegate;
+  return proxy;
+};
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary<UIApplicationLaunchOptionsKey,id> *)launchOptions {
+  [VitalHealthKitConfiguration automaticConfiguration];
+
+  if ([self.delegate respondsToSelector:@selector(application:didFinishLaunchingWithOptions:)]) {
+    return [self.delegate application:application didFinishLaunchingWithOptions:launchOptions];
+  } else {
+    return YES;
+  }
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector {
+  return [self.delegate respondsToSelector:aSelector];
+}
+
+- (BOOL)conformsToProtocol:(Protocol *)aProtocol {
+  return [self.delegate conformsToProtocol:aProtocol];
+}
+
+- (id)forwardingTargetForSelector:(SEL)aSelector {
+  return self.delegate;
+}
+
+@end

--- a/packages/vital-health-react-native/ios/VitalHealthKitConfiguration.h
+++ b/packages/vital-health-react-native/ios/VitalHealthKitConfiguration.h
@@ -2,6 +2,8 @@
 
 @interface VitalHealthKitConfiguration: NSObject
 
++ (void)load;
+
 + (void)automaticConfiguration;
 + (void)configureWithBackgroundDeliveryEnabled:(BOOL)backgroundDeliveryEnabled numberOfDaysToBackFill:(int)numberOfDaysToBackFill enableLogs:(BOOL)enableLogs;
 

--- a/packages/vital-health-react-native/ios/VitalHealthKitConfiguration.m
+++ b/packages/vital-health-react-native/ios/VitalHealthKitConfiguration.m
@@ -1,9 +1,22 @@
 #import "VitalHealthKitConfiguration.h"
+#import "VitalAppDelegateProxy.h"
 #import <React/RCTBridgeModule.h>
+#import <objc/runtime.h>
 
 @import VitalHealthKit;
 
 @implementation VitalHealthKitConfiguration
+
++ (void)load {
+  // Swap AppDelegate
+  Method setDelegateMethod = class_getInstanceMethod([UIApplication class], @selector(setDelegate:));
+  IMP originalImpl = method_getImplementation(setDelegateMethod);
+  void (*originalSetDelegate)(id, SEL, __attribute((ns_consumed)) id) = (typeof(originalSetDelegate)) originalImpl;
+  IMP newImpl = imp_implementationWithBlock(^void(id app, id delegate) {
+    originalSetDelegate(app, @selector(setDelegate:), [VitalAppDelegateProxy proxyWithBase:delegate]);
+  });
+  method_setImplementation(setDelegateMethod, newImpl);
+}
 
 + (void)automaticConfiguration {
   [VitalHealthKitClient automaticConfigurationWithCompletion:nil];

--- a/packages/vital-health-react-native/ios/VitalHealthReactNative.m
+++ b/packages/vital-health-react-native/ios/VitalHealthReactNative.m
@@ -58,3 +58,4 @@ RCT_EXTERN_METHOD(status)
 }
 
 @end
+


### PR DESCRIPTION
With this, RN and Expo customers no longer need to manually edit `AppDelegate.m` to call `[VitalHealthKitConfiguration automaticConfiguration]` for HealthKit Background Delivery.