### PR TITLE
VIT-7941: Update Expo plugin to support HealthKit background delivery

### DIFF
--- a/packages/vital-core-react-native/package.json
+++ b/packages/vital-core-react-native/package.json
@@ -13,6 +13,7 @@
     "ios",
     "cpp",
     "*.podspec",
+    "app.plugin.js",
     "!lib/typescript/example",
     "!ios/build",
     "!android/build",

--- a/packages/vital-health-react-native/app.plugin.js
+++ b/packages/vital-health-react-native/app.plugin.js
@@ -8,19 +8,27 @@ const { withPlugins } = require('@expo/config-plugins');
 const HEALTH_SHARE = 'Allow $(PRODUCT_NAME) to check health info';
 
 const withHealthKit = (config, { healthSharePermission } = {}) => {
-  // Add permissions
+
   config = withInfoPlist(config, (config) => {
+
     config.modResults.NSHealthShareUsageDescription =
       healthSharePermission ||
       config.modResults.NSHealthShareUsageDescription ||
       HEALTH_SHARE;
 
+    const declaredModes = config.modResults.UIBackgroundModes ?? [];
+
+    if (!declaredModes.includes('processing')) {
+      config.modResults.UIBackgroundModes = [...declaredModes, 'processing'];
+    }
+
     return config;
   });
 
-  // Add entitlements. These are automatically synced when using EAS build for production apps.
   config = withEntitlementsPlist(config, (config) => {
     config.modResults['com.apple.developer.healthkit'] = true;
+    config.modResults['com.apple.developer.healthkit.background-delivery'] = true;
+
     if (
       !Array.isArray(config.modResults['com.apple.developer.healthkit.access'])
     ) {

--- a/packages/vital-health-react-native/app.plugin.js
+++ b/packages/vital-health-react-native/app.plugin.js
@@ -2,8 +2,10 @@ const {
   withEntitlementsPlist,
   withInfoPlist,
   withAndroidManifest,
+  withAppDelegate,
 } = require('@expo/config-plugins');
 const { withPlugins } = require('@expo/config-plugins');
+const { addObjcImports, insertContentsInsideObjcFunctionBlock } = require('@expo/config-plugins/build/ios/codeMod');
 
 const HEALTH_SHARE = 'Allow $(PRODUCT_NAME) to check health info';
 
@@ -35,6 +37,21 @@ const withHealthKit = (config, { healthSharePermission } = {}) => {
       config.modResults['com.apple.developer.healthkit.access'] = [];
     }
 
+    return config;
+  });
+
+  config = withAppDelegate(config, (config) => {
+		let source = config.modResults.contents;
+
+    source = addObjcImports(source, ['"VitalHealthKitConfiguration.h"']);
+    source = insertContentsInsideObjcFunctionBlock(
+      source,
+      'application didFinishLaunchingWithOptions:',
+      '[VitalHealthKitConfiguration automaticConfiguration];',
+      { position: "head" },
+    );
+
+    config.modResults.contents = source;
     return config;
   });
 

--- a/packages/vital-health-react-native/package.json
+++ b/packages/vital-health-react-native/package.json
@@ -13,6 +13,7 @@
     "ios",
     "cpp",
     "*.podspec",
+    "app.plugin.js",
     "!lib/typescript/example",
     "!ios/build",
     "!android/build",


### PR DESCRIPTION
* Bundle app.plugin.js when publishing the packages
* Add missing mods for Info.plist and entitlements.
* Add missing mod for the AppDelegate `-didFinishLaunchingWithOptions:` message.