### PR TITLE
Expose iOS sleep data allow list in React Native SDK

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -13,9 +13,9 @@
     "@expo/vector-icons": "^15.0.3",
     "@react-navigation/native": "^7.1.14",
     "@react-navigation/native-stack": "^6.9.17",
-    "@tryvital/vital-core-react-native": "file:../lib/tryvital-vital-core-react-native-025cc433-6.0.1.tgz",
-    "@tryvital/vital-devices-react-native": "file:../lib/tryvital-vital-devices-react-native-025cc433-6.0.1.tgz",
-    "@tryvital/vital-health-react-native": "file:../lib/tryvital-vital-health-react-native-025cc433-6.0.1.tgz",
+    "@tryvital/vital-core-react-native": "file:../lib/tryvital-vital-core-react-native-da5729ab-6.0.1.tgz",
+    "@tryvital/vital-devices-react-native": "file:../lib/tryvital-vital-devices-react-native-da5729ab-6.0.1.tgz",
+    "@tryvital/vital-health-react-native": "file:../lib/tryvital-vital-health-react-native-da5729ab-6.0.1.tgz",
     "@tryvital/vital-node": "^3.1.544",
     "events": "^1.1.1",
     "expo": "^54.0.0",
@@ -78,6 +78,6 @@
     "node": ">=20.19.4"
   },
   "resolutions": {
-    "@tryvital/vital-core-react-native": "file:../lib/tryvital-vital-core-react-native-025cc433-6.0.1.tgz"
+    "@tryvital/vital-core-react-native": "file:../lib/tryvital-vital-core-react-native-da5729ab-6.0.1.tgz"
   }
 }

--- a/example/src/screens/UserScreen.tsx
+++ b/example/src/screens/UserScreen.tsx
@@ -141,8 +141,8 @@ export const UserScreen = ({ route }) => {
         )}
       </VStack>
 
-      {!isCurrentSDKUser && isSDKConfigured && (
-        <Button onPress={() => VitalCore.signOut()}>Reset SDK</Button>
+      {isSDKConfigured && (
+        <Button onPress={() => VitalCore.signOut()}>Sign Out</Button>
       )}
 
       {!isSDKConfigured && (

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2610,40 +2610,40 @@
   dependencies:
     tslib "^2.8.0"
 
-"@tryvital/vital-core-react-native@6.0.1", "@tryvital/vital-core-react-native@file:../lib/tryvital-vital-core-react-native-025cc433-6.0.1.tgz":
+"@tryvital/vital-core-react-native@6.0.1", "@tryvital/vital-core-react-native@file:../lib/tryvital-vital-core-react-native-da5729ab-6.0.1.tgz":
   version "6.0.1"
   uid "91f981de20e9f60719610f9ac9f73f8e658e03b3"
-  resolved "file:../lib/tryvital-vital-core-react-native-025cc433-6.0.1.tgz#91f981de20e9f60719610f9ac9f73f8e658e03b3"
+  resolved "file:../lib/tryvital-vital-core-react-native-da5729ab-6.0.1.tgz#91f981de20e9f60719610f9ac9f73f8e658e03b3"
 
-"@tryvital/vital-core-react-native@file:../lib/tryvital-vital-core-react-native-68e90dff-6.0.1.tgz":
+"@tryvital/vital-core-react-native@file:../lib/tryvital-vital-core-react-native-0dcbe684-6.0.1.tgz":
   version "6.0.1"
   uid "91f981de20e9f60719610f9ac9f73f8e658e03b3"
-  resolved "file:../lib/tryvital-vital-core-react-native-68e90dff-6.0.1.tgz#91f981de20e9f60719610f9ac9f73f8e658e03b3"
+  resolved "file:../lib/tryvital-vital-core-react-native-0dcbe684-6.0.1.tgz#91f981de20e9f60719610f9ac9f73f8e658e03b3"
 
-"@tryvital/vital-devices-react-native@file:../lib/tryvital-vital-devices-react-native-025cc433-6.0.1.tgz":
+"@tryvital/vital-devices-react-native@file:../lib/tryvital-vital-devices-react-native-0dcbe684-6.0.1.tgz":
+  version "6.0.1"
+  resolved "file:../lib/tryvital-vital-devices-react-native-0dcbe684-6.0.1.tgz#ed67eeedae5919591059a496282892fcd9ae789f"
+  dependencies:
+    "@tryvital/vital-core-react-native" "6.0.1"
+    react-native-permissions "^3.6.1"
+
+"@tryvital/vital-devices-react-native@file:../lib/tryvital-vital-devices-react-native-da5729ab-6.0.1.tgz":
   version "6.0.1"
   uid ed67eeedae5919591059a496282892fcd9ae789f
-  resolved "file:../lib/tryvital-vital-devices-react-native-025cc433-6.0.1.tgz#ed67eeedae5919591059a496282892fcd9ae789f"
+  resolved "file:../lib/tryvital-vital-devices-react-native-da5729ab-6.0.1.tgz#ed67eeedae5919591059a496282892fcd9ae789f"
   dependencies:
     "@tryvital/vital-core-react-native" "6.0.1"
     react-native-permissions "^3.6.1"
 
-"@tryvital/vital-devices-react-native@file:../lib/tryvital-vital-devices-react-native-68e90dff-6.0.1.tgz":
+"@tryvital/vital-health-react-native@file:../lib/tryvital-vital-health-react-native-0dcbe684-6.0.1.tgz":
   version "6.0.1"
-  resolved "file:../lib/tryvital-vital-devices-react-native-68e90dff-6.0.1.tgz#ed67eeedae5919591059a496282892fcd9ae789f"
-  dependencies:
-    "@tryvital/vital-core-react-native" "6.0.1"
-    react-native-permissions "^3.6.1"
-
-"@tryvital/vital-health-react-native@file:../lib/tryvital-vital-health-react-native-025cc433-6.0.1.tgz":
-  version "6.0.1"
-  resolved "file:../lib/tryvital-vital-health-react-native-025cc433-6.0.1.tgz#df1126ca8bfa8aa957939a9fa52d0d5e2bc0ead4"
+  resolved "file:../lib/tryvital-vital-health-react-native-0dcbe684-6.0.1.tgz#494d42ac3c15959e3eaef96e425da11cde4d1c9b"
   dependencies:
     "@tryvital/vital-core-react-native" "6.0.1"
 
-"@tryvital/vital-health-react-native@file:../lib/tryvital-vital-health-react-native-68e90dff-6.0.1.tgz":
+"@tryvital/vital-health-react-native@file:../lib/tryvital-vital-health-react-native-da5729ab-6.0.1.tgz":
   version "6.0.1"
-  resolved "file:../lib/tryvital-vital-health-react-native-68e90dff-6.0.1.tgz#37a00bdf0f9dafb6ac09ddd48bb94659f0d136b4"
+  resolved "file:../lib/tryvital-vital-health-react-native-da5729ab-6.0.1.tgz#0113d285acb007f6e4e21b5a5253546b5c84851e"
   dependencies:
     "@tryvital/vital-core-react-native" "6.0.1"
 

--- a/packages/vital-health-react-native/ios/VitalHealthReactNative.m
+++ b/packages/vital-health-react-native/ios/VitalHealthReactNative.m
@@ -7,6 +7,7 @@ RCT_EXTERN_METHOD(configure:(NSString *)provider
                   numberOfDaysToBackFill:(int)numberOfDaysToBackFill
                   enableLogs:(BOOL)enableLogs
                   connectionPolicy:(NSString *)connectionPolicy
+                  sleepDataAllowlist:(id)sleepDataAllowlist
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 

--- a/packages/vital-health-react-native/ios/VitalHealthReactNative.swift
+++ b/packages/vital-health-react-native/ios/VitalHealthReactNative.swift
@@ -64,13 +64,14 @@ class VitalHealthReactNative: RCTEventEmitter {
     return ["Status", "VitalHealthConnectionStatus"]
   }
 
-  @objc(configure:backgroundDeliveryEnabled:numberOfDaysToBackFill:enableLogs:connectionPolicy:resolver:rejecter:)
+  @objc(configure:backgroundDeliveryEnabled:numberOfDaysToBackFill:enableLogs:connectionPolicy:sleepDataAllowlist:resolver:rejecter:)
   func configure(
     _ provider: String,
     backgroundDeliveryEnabled: Bool,
     numberOfDaysToBackFill: Int,
     enableLogs: Bool,
     connectionPolicy: String,
+    sleepDataAllowlist: Any?,
     resolve: @escaping RCTPromiseResolveBlock,
     reject: RCTPromiseRejectBlock
   ) {
@@ -81,10 +82,24 @@ class VitalHealthReactNative: RCTEventEmitter {
         backgroundDeliveryEnabled: backgroundDeliveryEnabled,
         numberOfDaysToBackFill: numberOfDaysToBackFill,
         logsEnabled: enableLogs,
+        sleepDataAllowlist: decodeSleepAllowlist(sleepDataAllowlist),
         connectionPolicy: VitalHealthKitClient.ConnectionPolicy(rawValue: connectionPolicy) ?? .autoConnect
       )
     )
     resolve(())
+  }
+
+  /// Maps the value bridged from JS into the iOS SDK `AppAllowlist`.
+  /// `"all"` -> `.all`; `[String]` of bundle identifiers -> `.specific`; anything else
+  /// (incl. `nil`/`NSNull` for an unset value) falls back to the SDK default allow list.
+  private func decodeSleepAllowlist(_ value: Any?) -> AppAllowlist {
+    if let string = value as? String, string == "all" {
+      return .all
+    }
+    if let bundleIdentifiers = value as? [String] {
+      return .specific(bundleIdentifiers.map { AppIdentifier(rawValue: $0) })
+    }
+    return .specific(AppIdentifier.defaultsleepDataAllowlist)
   }
 
   @objc(setUserId:userId:resolver:rejecter:)

--- a/packages/vital-health-react-native/src/health_config.ts
+++ b/packages/vital-health-react-native/src/health_config.ts
@@ -34,7 +34,7 @@ export class IOSHealthConfig {
    *
    * - `undefined` (default): use the SDK's built-in default allow list of known sleep providers.
    * - `'all'`: accept sleep data from every source.
-   * - `string[]`: accept only the listed source app bundle identifiers. Use {@link SleepDataApp}
+   * - `string[]`: accept only the listed source app bundle identifiers. Use {@link iOSAppIdentifier}
    *   for the known providers, or pass any raw bundle identifier string.
    *
    * Manually-entered sleep data is always allowed, regardless of this setting.
@@ -46,7 +46,7 @@ export class IOSHealthConfig {
  * Known sleep data source apps and their bundle identifiers, mirroring the iOS SDK's
  * `AppIdentifier` constants. Use these with {@link IOSHealthConfig.sleepDataAllowlist}.
  */
-export const SleepDataApp = {
+export const iOSAppIdentifier = {
   appleHealthKit: 'com.apple.health',
   oura: 'com.ouraring.oura',
   withings: 'com.withings.wiScaleNG',

--- a/packages/vital-health-react-native/src/health_config.ts
+++ b/packages/vital-health-react-native/src/health_config.ts
@@ -29,4 +29,45 @@ export class AndroidHealthConfig {
 export class IOSHealthConfig {
   dataPushMode = 'automatic';
   backgroundDeliveryEnabled = true;
+  /**
+   * Controls which apps/sources are allowed to contribute sleep data during sync (iOS only).
+   *
+   * - `undefined` (default): use the SDK's built-in default allow list of known sleep providers.
+   * - `'all'`: accept sleep data from every source.
+   * - `string[]`: accept only the listed source app bundle identifiers. Use {@link SleepDataApp}
+   *   for the known providers, or pass any raw bundle identifier string.
+   *
+   * Manually-entered sleep data is always allowed, regardless of this setting.
+   */
+  sleepDataAllowlist?: SleepDataAllowlist;
 }
+
+/**
+ * Known sleep data source apps and their bundle identifiers, mirroring the iOS SDK's
+ * `AppIdentifier` constants. Use these with {@link IOSHealthConfig.sleepDataAllowlist}.
+ */
+export const SleepDataApp = {
+  appleHealthKit: 'com.apple.health',
+  oura: 'com.ouraring.oura',
+  withings: 'com.withings.wiScaleNG',
+  whoop: 'com.whoop.iphone',
+  garmin: 'com.garmin.connect.mobile',
+  fitbit: 'com.fitbit.FitbitMobile',
+  polar: 'fi.polar.polarflow',
+  coros: 'com.coros.coros',
+  suunto: 'com.sports-tracker.suunto.iphone',
+  xiaomi: 'com.xiaomi.miwatch.pro',
+  muse: 'com.interaxon.muse',
+  biostrap: 'com.biostrap.Biostrap',
+  cardiomood: 'com.corsanohealth.cardiomood',
+  eightsleep: 'com.eightsleep.Eight',
+  zepp: 'com.huami.watch',
+  zeppLife: 'HM.wristband',
+  sleepCycle: 'com.lexwarelabs.goodmorning',
+} as const;
+
+/**
+ * Sleep data allow list value. `'all'` accepts every source; a `string[]` of bundle identifiers
+ * accepts only those sources; leaving it `undefined` uses the SDK default.
+ */
+export type SleepDataAllowlist = 'all' | string[];

--- a/packages/vital-health-react-native/src/index.tsx
+++ b/packages/vital-health-react-native/src/index.tsx
@@ -346,7 +346,8 @@ export class VitalHealth {
         healthConfig.iOSConfig.backgroundDeliveryEnabled,
         healthConfig.numberOfDaysToBackFill,
         healthConfig.logsEnabled,
-        healthConfig.connectionPolicy
+        healthConfig.connectionPolicy,
+        healthConfig.iOSConfig.sleepDataAllowlist ?? null
       );
     }
   }


### PR DESCRIPTION
## Summary

- Adds `SleepDataApp` named constants and `SleepDataAllowlist` type to the public TS API, mirroring the iOS SDK's `AppIdentifier` enum
- Adds `sleepDataAllowlist?: SleepDataAllowlist` to `IOSHealthConfig` — `undefined` keeps the SDK default (~16 providers), `'all'` accepts every source, or pass a `string[]` of bundle identifiers
- Threads the value through the existing `configure()` bridge call (ObjC `.m` declaration + Swift implementation)
- No iOS SDK / podspec bump required — `VitalHealthKit ~> 1.8.8` already exposes `AppAllowlist` and `AppIdentifier`

## Usage

```ts
import { HealthConfig, SleepDataApp, VitalHealth } from '@tryvital/vital-health-react-native';

const config = new HealthConfig();

// Specific known sources using named constants
config.iOSConfig.sleepDataAllowlist = [SleepDataApp.oura, SleepDataApp.whoop];

// Mix named constants with any custom bundle identifier
config.iOSConfig.sleepDataAllowlist = [
  SleepDataApp.oura,
  'com.someapp.custom',
];

// Accept sleep data from every source
config.iOSConfig.sleepDataAllowlist = 'all';

// Leave unset to use the SDK default (~16 known providers)
await VitalHealth.configure(config);
